### PR TITLE
Add missing httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ license = "Apache-2.0"
 classifiers = []
 requires-python = ">=3.9"
 dependencies = [
-    "llm>=0.24"
+    "llm>=0.24",
+    "httpx"
 ]
 
 [build-system]


### PR DESCRIPTION
Adds the missing `httpx` dependency required by `llm_hacker_news.py` to `pyproject.toml`. Fixes potential `ImportError`.