### PR TITLE
Allow loading Hacker News articles by ID or full URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,18 @@ llm install llm-hacker-news
 ```
 ## Usage
 
-You can feed a full conversation thread from [Hacker News](https://news.ycombinator.com/) into LLM using the `hn:` [fragment](https://llm.datasette.io/en/stable/fragments.html) with the ID of the conversation. For example:
+You can feed a full conversation thread from [Hacker News](https://news.ycombinator.com/) into LLM using the `hn:` [fragment](https://llm.datasette.io/en/stable/fragments.html) with either the ID of the conversation or the full item URL. For example:
 
 ```bash
 llm -f hn:43615912 'summary with illustrative direct quotes'
 ```
+
+Or using the full URL:
+
+```bash
+llm -f hn:https://news.ycombinator.com/item?id=43615912 'summary with illustrative direct quotes'
+```
+
 Item IDs can be found in the URL of the conversation thread.
 
 ## Development

--- a/llm_hacker_news.py
+++ b/llm_hacker_news.py
@@ -16,16 +16,21 @@ def hacker_news_loader(argument: str) -> llm.Fragment:
     Given a Hacker News article ID returns the full nested conversation.
 
     For example: -f hn:43875136
+    Or with complete uri: -f hn:https://news.ycombinator.com/item?id=43875136
     """
     try:
-        response = httpx.get(f"https://hn.algolia.com/api/v1/items/{argument}")
+        number = re.search(r"\d+", argument)
+        if not number:
+            raise ValueError(f"Invalid Hacker News ID or URI: {argument}")
+        numeric_id = int(number.group(0))
+        response = httpx.get(f"https://hn.algolia.com/api/v1/items/{numeric_id}")
         response.raise_for_status()
         data = response.json()
     except Exception as ex:
         raise ValueError(f"Could not load Hacker News {argument}: {str(ex)}")
     return llm.Fragment(
         process_hn_comments(data),
-        source=f"https://news.ycombinator.com/item?id={argument}",
+        source=f"https://news.ycombinator.com/item?id={numeric_id}",
     )
 
 

--- a/tests/test_hacker_news.py
+++ b/tests/test_hacker_news.py
@@ -57,3 +57,9 @@ EXAMPLE = {
         },
     ],
 }
+
+def test_hacker_news_loader_with_uri(httpx_mock):
+    httpx_mock.add_response(json=EXAMPLE)
+    fragment = hacker_news_loader("https://news.ycombinator.com/item?id=123456")
+    assert isinstance(fragment, llm.Fragment)
+    assert fragment.source == "https://news.ycombinator.com/item?id=123456"


### PR DESCRIPTION
Sometimes its easier to grab the full uri instead of selecting the id of a posting.
This patch adds parsing of the id from the fragment argument to allow this workflow.